### PR TITLE
semicolon bug fix, underscores allowed in names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,7 @@ keywords = ["ebnf", "bnf"]
 [dependencies]
 nom = "7"
 parse-hyperlinks = "0.23.3"
+serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
+insta = { version = "1.26.0", features = ["yaml"] }

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ almost most syntactic conventions on Wikipedia's page.
 The following example is taken from EBNF Evaluator:
 
 ```ebnf
-filter ::= ( first ' ' )? ( number '~ ' )? ( number '-' number ) ( ' ' number '~' )? ( ' hz' )? ( ' b' )? ( ' i' )? ( ' a' )?
-first  ::= #'[a-za-z][a-za-z0-9_+]*'
-number ::= digits ( ( '.' | ',' ) digits? )?
-digits ::= #'[0-9]+'
+filter ::= ( first ' ' )? ( number '~ ' )? ( number '-' number ) ( ' ' number '~' )? ( ' hz' )? ( ' b' )? ( ' i' )? ( ' a' )?;
+first  ::= #'[a-za-z][a-za-z0-9_+]*';
+number ::= digits ( ( '.' | ',' ) digits? )?;
+digits ::= #'[0-9]+';
 ```
 
 ## How to use this library?
@@ -27,10 +27,10 @@ extern crate ebnf;
 
 fn main() {
     let source = r"
-        filter ::= ( first ' ' )? ( number '~ ' )? ( number '-' number ) ( ' ' number '~' )? ( ' hz' )? ( ' b' )? ( ' i' )? ( ' a' )?
-        first  ::= #'[a-za-z][a-za-z0-9_+]*'
-        number ::= digits ( ( '.' | ',' ) digits? )?
-        digits ::= #'[0-9]+'
+        filter ::= ( first ' ' )? ( number '~ ' )? ( number '-' number ) ( ' ' number '~' )? ( ' hz' )? ( ' b' )? ( ' i' )? ( ' a' )?;
+        first  ::= #'[a-za-z][a-za-z0-9_+]*';
+        number ::= digits ( ( '.' | ',' ) digits? )?;
+        digits ::= #'[0-9]+';
     ";
 
     let result = ebnf::get_grammar(source);

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,7 +1,7 @@
-use serde::{Serialize};
+use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Expression {
-   pub lhs: String,
-   pub rhs: crate::Node,
+    pub lhs: String,
+    pub rhs: crate::Node,
 }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, Clone)]
+use serde::{Serialize};
+
+#[derive(Debug, Clone, Serialize)]
 pub struct Expression {
    pub lhs: String,
    pub rhs: crate::Node,

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -1,7 +1,7 @@
 use crate::expression::Expression;
-use serde::{Serialize};
+use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Grammar {
-    pub expressions: Vec<Expression>
+    pub expressions: Vec<Expression>,
 }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -1,6 +1,7 @@
 use crate::expression::Expression;
+use serde::{Serialize};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Grammar {
     pub expressions: Vec<Expression>
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,28 +1,28 @@
 //! ebnf - A successor bnf parsing library of bnf parsing library, for parsing Extended Backus–Naur form context-free grammars
-//! 
+//!
 //! The code is available on [GitHub](https://github.com/ChAoSUnItY/ebnf)
-//! 
+//!
 //! ## Disclaimer:
-//! There are various variants of EBNF, which uses somewhat different syntactic conventions. This library 
-//! takes [EBNF Evaluator](https://mdkrajnak.github.io/ebnftest/)'s example code as standard, which has 
+//! There are various variants of EBNF, which uses somewhat different syntactic conventions. This library
+//! takes [EBNF Evaluator](https://mdkrajnak.github.io/ebnftest/)'s example code as standard, which has
 //! almost most syntactic conventions on Wikipedia's page.
-//! 
+//!
 //! ## What does a valid EBNF grammar looks like?
-//! 
+//!
 //! The following example is taken from EBNF Evaluator:
-//! 
+//!
 //! ```ebnf
 //! filter ::= ( first ' ' )? ( number '~ ' )? ( number '-' number ) ( ' ' number '~' )? ( ' hz' )? ( ' b' )? ( ' i' )? ( ' a' )?;
 //! first  ::= #'[a-za-z][a-za-z0-9_+]*';
 //! number ::= digits ( ( '.' | ',' ) digits? )?;
 //! digits ::= #'[0-9]+';
 //! ```
-//! 
+//!
 //! ## How to use this library?
-//! 
+//!
 //! ```rust
 //! extern crate ebnf;
-//! 
+//!
 //! fn main() {
 //!     let source = r"
 //!         filter ::= ( first ' ' )? ( number '~ ' )? ( number '-' number ) ( ' ' number '~' )? ( ' hz' )? ( ' b' )? ( ' i' )? ( ' a' )?;
@@ -30,7 +30,7 @@
 //!         number ::= digits ( ( '.' | ',' ) digits? )?;
 //!         digits ::= #'[0-9]+';
 //!     ";
-//! 
+//!
 //!     let result = ebnf::get_grammar(source);
 //! }
 //! ```
@@ -43,7 +43,7 @@ mod node;
 mod parser;
 pub use expression::Expression;
 pub use grammar::Grammar;
-pub use node::{Node, SymbolKind, RegexExtKind};
+pub use node::{Node, RegexExtKind, SymbolKind};
 
 // get and parse EBNF grammar source into data structure ebnf::Grammar
 pub fn get_grammar(input: &str) -> Result<Grammar, nom::Err<nom::error::VerboseError<&str>>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,10 +12,10 @@
 //! The following example is taken from EBNF Evaluator:
 //! 
 //! ```ebnf
-//! filter ::= ( first ' ' )? ( number '~ ' )? ( number '-' number ) ( ' ' number '~' )? ( ' hz' )? ( ' b' )? ( ' i' )? ( ' a' )?
-//! first  ::= #'[a-za-z][a-za-z0-9_+]*'
-//! number ::= digits ( ( '.' | ',' ) digits? )?
-//! digits ::= #'[0-9]+'
+//! filter ::= ( first ' ' )? ( number '~ ' )? ( number '-' number ) ( ' ' number '~' )? ( ' hz' )? ( ' b' )? ( ' i' )? ( ' a' )?;
+//! first  ::= #'[a-za-z][a-za-z0-9_+]*';
+//! number ::= digits ( ( '.' | ',' ) digits? )?;
+//! digits ::= #'[0-9]+';
 //! ```
 //! 
 //! ## How to use this library?
@@ -25,10 +25,10 @@
 //! 
 //! fn main() {
 //!     let source = r"
-//!         filter ::= ( first ' ' )? ( number '~ ' )? ( number '-' number ) ( ' ' number '~' )? ( ' hz' )? ( ' b' )? ( ' i' )? ( ' a' )?
-//!         first  ::= #'[a-za-z][a-za-z0-9_+]*'
-//!         number ::= digits ( ( '.' | ',' ) digits? )?
-//!         digits ::= #'[0-9]+'
+//!         filter ::= ( first ' ' )? ( number '~ ' )? ( number '-' number ) ( ' ' number '~' )? ( ' hz' )? ( ' b' )? ( ' i' )? ( ' a' )?;
+//!         first  ::= #'[a-za-z][a-za-z0-9_+]*';
+//!         number ::= digits ( ( '.' | ',' ) digits? )?;
+//!         digits ::= #'[0-9]+';
 //!     ";
 //! 
 //!     let result = ebnf::get_grammar(source);

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,4 @@
-use serde::{Serialize};
+use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize)]
 pub enum Node {
@@ -18,7 +18,7 @@ pub enum Node {
 pub enum RegexExtKind {
     Repeat0,
     Repeat1,
-    Optional
+    Optional,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, Clone)]
+use serde::{Serialize};
+
+#[derive(Debug, Clone, Serialize)]
 pub enum Node {
     String(String),
     RegexString(String),
@@ -12,14 +14,14 @@ pub enum Node {
     Unknown,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub enum RegexExtKind {
     Repeat0,
     Repeat1,
     Optional
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub enum SymbolKind {
     Concatenation,
     Alternation,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -20,7 +20,8 @@ type Res<T, U> = IResult<T, U, VerboseError<T>>;
 fn parse_lhs(input: &str) -> Res<&str, String> {
     let (input, lhs) = preceded(
         complete::multispace0,
-        many1(alt((complete::alphanumeric1,tag("_")))))(input)?;
+        many1(alt((complete::alphanumeric1, tag("_")))),
+    )(input)?;
     let (input, _) = preceded(complete::multispace0, alt((tag("="), tag("::="))))(input)?;
 
     Ok((input, lhs.join("").trim_end().to_owned()))
@@ -30,8 +31,9 @@ fn parse_rhs(input: &str) -> Res<&str, Node> {
     let (input, rhs) = preceded(
         complete::multispace0,
         terminated(
-            parse_multiple, 
-            preceded(complete::multispace0, complete::char(';'))),
+            parse_multiple,
+            preceded(complete::multispace0, complete::char(';')),
+        ),
     )(input)?;
 
     Ok((input, rhs))
@@ -58,9 +60,11 @@ fn parse_regex_string(input: &str) -> Res<&str, Node> {
 fn parse_terminal(input: &str) -> Res<&str, Node> {
     let (input, symbol) = preceded(
         complete::multispace0,
-        terminated(many1(alt((complete::alphanumeric1,tag("_")))), complete::multispace0),
+        terminated(
+            many1(alt((complete::alphanumeric1, tag("_")))),
+            complete::multispace0,
+        ),
     )(input)?;
-
 
     Ok((input, Node::Terminal(symbol.join(""))))
 }
@@ -230,40 +234,40 @@ mod test {
     }
     #[test]
     fn simple_alternation() {
-     let source = r"
+        let source = r"
          filter ::= a | b;
          a ::= 'a';
          b ::= 'b';
      ";
-     let result = parse_expressions(source).unwrap();
-     assert_yaml_snapshot!(result)
+        let result = parse_expressions(source).unwrap();
+        assert_yaml_snapshot!(result)
     }
     #[test]
     fn space_before_semi() {
-     let source = r"
+        let source = r"
          filter ::= a | b ;
          a ::= 'a';
          b ::= 'b';
      ";
-     let result = parse_expressions(source).unwrap();
-     assert_yaml_snapshot!(result)
+        let result = parse_expressions(source).unwrap();
+        assert_yaml_snapshot!(result)
     }
     #[test]
     fn underscore() {
-     let source = r"
+        let source = r"
          filter ::= a_b;
          a_b ::= 'a' | 'b';
      ";
-     let result = parse_expressions(source).unwrap();
-     assert_yaml_snapshot!(result)
+        let result = parse_expressions(source).unwrap();
+        assert_yaml_snapshot!(result)
     }
     #[test]
     fn multiple_underscores() {
-     let source = r"
+        let source = r"
          filter ::= a_b_cat;
          a_b_cat ::= 'a' | 'b';
      ";
-     let result = parse_expressions(source).unwrap();
-     assert_yaml_snapshot!(result)
+        let result = parse_expressions(source).unwrap();
+        assert_yaml_snapshot!(result)
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,22 +12,26 @@ use parse_hyperlinks::take_until_unbalanced;
 
 use crate::{
     node::{RegexExtKind, SymbolKind},
-    Expression, Grammar, Node,
+    Expression, Node,
 };
 
 type Res<T, U> = IResult<T, U, VerboseError<T>>;
 
-fn parse_lhs(input: &str) -> Res<&str, &str> {
-    let (input, lhs) = preceded(complete::multispace0, complete::alphanumeric1)(input)?;
+fn parse_lhs(input: &str) -> Res<&str, String> {
+    let (input, lhs) = preceded(
+        complete::multispace0,
+        many1(alt((complete::alphanumeric1,tag("_")))))(input)?;
     let (input, _) = preceded(complete::multispace0, alt((tag("="), tag("::="))))(input)?;
 
-    Ok((input, lhs.trim_end()))
+    Ok((input, lhs.join("").trim_end().to_owned()))
 }
 
 fn parse_rhs(input: &str) -> Res<&str, Node> {
     let (input, rhs) = preceded(
         complete::multispace0,
-        terminated(parse_multiple, complete::char(';')),
+        terminated(
+            parse_multiple, 
+            preceded(complete::multispace0, complete::char(';'))),
     )(input)?;
 
     Ok((input, rhs))
@@ -54,10 +58,11 @@ fn parse_regex_string(input: &str) -> Res<&str, Node> {
 fn parse_terminal(input: &str) -> Res<&str, Node> {
     let (input, symbol) = preceded(
         complete::multispace0,
-        terminated(complete::alphanumeric1, complete::multispace0),
+        terminated(many1(alt((complete::alphanumeric1,tag("_")))), complete::multispace0),
     )(input)?;
 
-    Ok((input, Node::Terminal(symbol.to_string())))
+
+    Ok((input, Node::Terminal(symbol.join(""))))
 }
 
 fn parse_multiple(input: &str) -> Res<&str, Node> {
@@ -208,6 +213,7 @@ pub(crate) fn parse_expressions(input: &str) -> Res<&str, Vec<Expression>> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use insta::assert_yaml_snapshot;
 
     #[test]
     fn test_parse() {
@@ -221,5 +227,43 @@ mod test {
         let (input, vec) = parse_expressions(src).unwrap();
 
         println!("{:#?}", vec);
+    }
+    #[test]
+    fn simple_alternation() {
+     let source = r"
+         filter ::= a | b;
+         a ::= 'a';
+         b ::= 'b';
+     ";
+     let result = parse_expressions(source).unwrap();
+     assert_yaml_snapshot!(result)
+    }
+    #[test]
+    fn space_before_semi() {
+     let source = r"
+         filter ::= a | b ;
+         a ::= 'a';
+         b ::= 'b';
+     ";
+     let result = parse_expressions(source).unwrap();
+     assert_yaml_snapshot!(result)
+    }
+    #[test]
+    fn underscore() {
+     let source = r"
+         filter ::= a_b;
+         a_b ::= 'a' | 'b';
+     ";
+     let result = parse_expressions(source).unwrap();
+     assert_yaml_snapshot!(result)
+    }
+    #[test]
+    fn multiple_underscores() {
+     let source = r"
+         filter ::= a_b_cat;
+         a_b_cat ::= 'a' | 'b';
+     ";
+     let result = parse_expressions(source).unwrap();
+     assert_yaml_snapshot!(result)
     }
 }

--- a/src/snapshots/ebnf__parser__test__multiple_underscores.snap
+++ b/src/snapshots/ebnf__parser__test__multiple_underscores.snap
@@ -1,0 +1,15 @@
+---
+source: src/parser.rs
+expression: result
+---
+- "\n         filter ::= a_b_cat;\n         a_b_cat ::= 'a' | 'b';\n     "
+- - lhs: filter
+    rhs:
+      Terminal: a_b_cat
+  - lhs: a_b_cat
+    rhs:
+      Symbol:
+        - String: a
+        - Alternation
+        - String: b
+

--- a/src/snapshots/ebnf__parser__test__simple_alternation.snap
+++ b/src/snapshots/ebnf__parser__test__simple_alternation.snap
@@ -1,0 +1,18 @@
+---
+source: src/parser.rs
+expression: result
+---
+- "\n         filter ::= a | b;\n         a ::= 'a';\n         b ::= 'b';\n     "
+- - lhs: filter
+    rhs:
+      Symbol:
+        - Terminal: a
+        - Alternation
+        - Terminal: b
+  - lhs: a
+    rhs:
+      String: a
+  - lhs: b
+    rhs:
+      String: b
+

--- a/src/snapshots/ebnf__parser__test__space_before_semi.snap
+++ b/src/snapshots/ebnf__parser__test__space_before_semi.snap
@@ -1,0 +1,18 @@
+---
+source: src/parser.rs
+expression: result
+---
+- "\n         filter ::= a | b ;\n         a ::= 'a';\n         b ::= 'b';\n     "
+- - lhs: filter
+    rhs:
+      Symbol:
+        - Terminal: a
+        - Alternation
+        - Terminal: b
+  - lhs: a
+    rhs:
+      String: a
+  - lhs: b
+    rhs:
+      String: b
+

--- a/src/snapshots/ebnf__parser__test__underscore.snap
+++ b/src/snapshots/ebnf__parser__test__underscore.snap
@@ -1,0 +1,15 @@
+---
+source: src/parser.rs
+expression: result
+---
+- "\n         filter ::= a_b;\n         a_b ::= 'a' | 'b';\n     "
+- - lhs: filter
+    rhs:
+      Terminal: a_b
+  - lhs: a_b
+    rhs:
+      Symbol:
+        - String: a
+        - Alternation
+        - String: b
+

--- a/src/snapshots/ebnf__parser__test__underscores.snap
+++ b/src/snapshots/ebnf__parser__test__underscores.snap
@@ -1,0 +1,15 @@
+---
+source: src/parser.rs
+expression: result
+---
+- "\n         filter ::= a_b;\n         a_b ::= 'a' | 'b';\n     "
+- - lhs: filter
+    rhs:
+      Terminal: a_b
+  - lhs: a_b
+    rhs:
+      Symbol:
+        - String: a
+        - Alternation
+        - String: b
+


### PR DESCRIPTION
three alterations:
1. semicolons weren't allowed in terminals' names.
2. whitespace wasn't allowed before semicolons.
3. semicolons added in readme example

note:
I am very unfamiliar with this nested functional parser design and rust so my implementations might be naive.

