### PR TITLE
alternation and concatenation precedence 

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -138,13 +138,13 @@ fn parse_symbol(input: &str) -> Res<&str, (SymbolKind, Node)> {
 }
 
 fn parse_concatenation(input: &str) -> Res<&str, (SymbolKind, Node)> {
-    let (input, node) = preceded(complete::char(','), parse_multiple)(input)?;
+    let (input, node) = preceded(complete::char(','), parse_node)(input)?;
 
     Ok((input, (SymbolKind::Concatenation, node)))
 }
 
 fn parse_alternation(input: &str) -> Res<&str, (SymbolKind, Node)> {
-    let (input, node) = preceded(complete::char('|'), parse_multiple)(input)?;
+    let (input, node) = preceded(complete::char('|'), parse_node)(input)?;
 
     Ok((input, (SymbolKind::Alternation, node)))
 }
@@ -266,4 +266,21 @@ mod test {
      let result = parse_expressions(source).unwrap();
      assert_yaml_snapshot!(result)
     }
+    #[test]
+    fn alternation_precidence() {
+     let source = r"
+         filter ::= 'a' | 'b' 'c';
+     ";
+     let result = parse_expressions(source).unwrap();
+     assert_yaml_snapshot!(result)
+    }
+    #[test]
+    fn alternation_precidence_group() {
+     let source = r"
+         filter ::= 'a' | ('b' 'c');
+     ";
+     let result = parse_expressions(source).unwrap();
+     assert_yaml_snapshot!(result)
+    }
+
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -272,19 +272,18 @@ mod test {
     }
     #[test]
     fn alternation_precidence() {
-     let source = r"
+        let source = r"
          filter ::= 'a' | 'b' 'c';
      ";
-     let result = parse_expressions(source).unwrap();
-     assert_yaml_snapshot!(result)
+        let result = parse_expressions(source).unwrap();
+        assert_yaml_snapshot!(result)
     }
     #[test]
     fn alternation_precidence_group() {
-     let source = r"
+        let source = r"
          filter ::= 'a' | ('b' 'c');
      ";
-     let result = parse_expressions(source).unwrap();
-     assert_yaml_snapshot!(result)
+        let result = parse_expressions(source).unwrap();
+        assert_yaml_snapshot!(result)
     }
-
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -279,9 +279,41 @@ mod test {
         assert_yaml_snapshot!(result)
     }
     #[test]
+    fn alternation_precidence_multiple() {
+        let source = r"
+         filter ::= 'a' | 'b' | 'c';
+     ";
+        let result = parse_expressions(source).unwrap();
+        assert_yaml_snapshot!(result)
+    }
+    #[test]
+    fn alternation_precidence_nested() {
+        let source = r"
+         filter ::= 'a' | 'b'  'c' | 'd';
+     ";
+        let result = parse_expressions(source).unwrap();
+        assert_yaml_snapshot!(result)
+    }
+    #[test]
     fn alternation_precidence_group() {
         let source = r"
          filter ::= 'a' | ('b' 'c');
+     ";
+        let result = parse_expressions(source).unwrap();
+        assert_yaml_snapshot!(result)
+    }
+    #[test]
+    fn concat_precidence() {
+        let source = r"
+         filter ::= 'a' | 'b' , 'c' , 'd';
+     ";
+        let result = parse_expressions(source).unwrap();
+        assert_yaml_snapshot!(result)
+    }
+    #[test]
+    fn concat_precidence_reverse() {
+        let source = r"
+         filter ::= 'a' , 'b' , 'c' | 'd';
      ";
         let result = parse_expressions(source).unwrap();
         assert_yaml_snapshot!(result)

--- a/src/snapshots/ebnf__parser__test__alternation_precidence.snap
+++ b/src/snapshots/ebnf__parser__test__alternation_precidence.snap
@@ -1,0 +1,14 @@
+---
+source: src/parser.rs
+expression: result
+---
+- "\n         filter ::= 'a' | 'b' 'c';\n     "
+- - lhs: filter
+    rhs:
+      Multiple:
+        - Symbol:
+            - String: a
+            - Alternation
+            - String: b
+        - String: c
+

--- a/src/snapshots/ebnf__parser__test__alternation_precidence_group.snap
+++ b/src/snapshots/ebnf__parser__test__alternation_precidence_group.snap
@@ -1,0 +1,15 @@
+---
+source: src/parser.rs
+expression: result
+---
+- "\n         filter ::= 'a' | ('b' 'c');\n     "
+- - lhs: filter
+    rhs:
+      Symbol:
+        - String: a
+        - Alternation
+        - Group:
+            Multiple:
+              - String: b
+              - String: c
+

--- a/src/snapshots/ebnf__parser__test__alternation_precidence_multiple.snap
+++ b/src/snapshots/ebnf__parser__test__alternation_precidence_multiple.snap
@@ -1,0 +1,15 @@
+---
+source: src/parser.rs
+expression: result
+---
+- "\n         filter ::= 'a' | 'b' | 'c';\n     "
+- - lhs: filter
+    rhs:
+      Symbol:
+        - String: a
+        - Alternation
+        - Symbol:
+            - String: b
+            - Alternation
+            - String: c
+

--- a/src/snapshots/ebnf__parser__test__alternation_precidence_nested.snap
+++ b/src/snapshots/ebnf__parser__test__alternation_precidence_nested.snap
@@ -1,0 +1,17 @@
+---
+source: src/parser.rs
+expression: result
+---
+- "\n         filter ::= 'a' | 'b'  'c' | 'd';\n     "
+- - lhs: filter
+    rhs:
+      Multiple:
+        - Symbol:
+            - String: a
+            - Alternation
+            - String: b
+        - Symbol:
+            - String: c
+            - Alternation
+            - String: d
+

--- a/src/snapshots/ebnf__parser__test__concat_precidence.snap
+++ b/src/snapshots/ebnf__parser__test__concat_precidence.snap
@@ -1,0 +1,18 @@
+---
+source: src/parser.rs
+expression: result
+---
+- "\n         filter ::= 'a' | 'b' , 'c' , 'd';\n     "
+- - lhs: filter
+    rhs:
+      Symbol:
+        - String: a
+        - Alternation
+        - Symbol:
+            - String: b
+            - Concatenation
+            - Symbol:
+                - String: c
+                - Concatenation
+                - String: d
+

--- a/src/snapshots/ebnf__parser__test__concat_precidence_reverse.snap
+++ b/src/snapshots/ebnf__parser__test__concat_precidence_reverse.snap
@@ -1,0 +1,18 @@
+---
+source: src/parser.rs
+expression: result
+---
+- "\n         filter ::= 'a' , 'b' , 'c' | 'd';\n     "
+- - lhs: filter
+    rhs:
+      Symbol:
+        - String: a
+        - Concatenation
+        - Symbol:
+            - String: b
+            - Concatenation
+            - Symbol:
+                - String: c
+                - Alternation
+                - String: d
+


### PR DESCRIPTION
in my opinion, 'a' | 'b' 'c', should be treated like 'a' * 'b' + c where '|' binds 'tighter' than ' '