### PR TITLE
Add CI to ensure PR follows conventions

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -10,6 +10,9 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          components: rustfmt
+      - name: Format check
+        run: cargo fmt --check
       - name: Check build (Strict)
         run: cargo build --verbose --release --features "strict"
       - name: Run tests

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -1,0 +1,22 @@
+on: [pull_request]
+
+jobs:
+  build_test:
+    runs-on: ubuntu-latest
+    name: Build and Test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Check build (Strict)
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose --release --features "strict"
+      - name: Run tests
+        uses: action-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -11,12 +11,6 @@ jobs:
         with:
           toolchain: stable
       - name: Check build (Strict)
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose --release --features "strict"
+        run: cargo build --verbose --release --features "strict"
       - name: Run tests
-        uses: action-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose
+        run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["ebnf", "bnf"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+strict = []
+
 [dependencies]
 nom = "7"
 parse-hyperlinks = "0.23.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "strict", deny(warnings))]
+
 //! ebnf - A successor bnf parsing library of bnf parsing library, for parsing Extended Backus–Naur form context-free grammars
 //!
 //! The code is available on [GitHub](https://github.com/ChAoSUnItY/ebnf)


### PR DESCRIPTION
- Add PR CIincluding strict building (no warning allowed), and followed by a test.