### PR TITLE
Prepare for 0.1.3

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -1,3 +1,5 @@
+name: Pull Request CI
+
 on: [pull_request]
 
 jobs:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,3 +1,5 @@
+name: CI
+
 on: [push]
 
 jobs:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   build_test:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,19 @@
+on: [push]
+
+jobs:
+  build_test:
+    runs-on: ubuntu-latest
+    name: Build and Test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+      - name: Format check
+        run: cargo fmt --check
+      - name: Check build (Strict)
+        run: cargo build --verbose --release --features "strict"
+      - name: Run tests
+        run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ebnf"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT"
 description = "A successor bnf parsing library of bnf parsing library, for parsing Extended Backus–Naur form context-free grammars"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # ebnf
 
+[![Crates.io](https://img.shields.io/crates/v/ebnf)](https://crates.io/crates/ebnf)
+[![Docs](https://docs.rs/ebnf/badge.svg)](https://docs.rs/ebnf/)
+[![.github/workflows/push.yml](https://github.com/ChAoSUnItY/ebnf/actions/workflows/push.yml/badge.svg)](https://github.com/ChAoSUnItY/ebnf/actions/workflows/push.yml)
+
 > A successor bnf parsing library of bnf parsing library, for parsing Extended Backus–Naur form context-free grammars
 
 The code is available on [GitHub](https://github.com/ChAoSUnItY/ebnf)


### PR DESCRIPTION
- Adds push CI in case contributors directly push some harmful code breaks CI rules.
- Adds badges for build version on crates.io and latest CI status in README
- Update version to 0.1.3 and publish on crates.io